### PR TITLE
Fix #60 and #62 and upgrade to 1.65.1 while at it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,37 +56,37 @@ matrix:
       - <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49 CONAN_CURRENT_PAGE=4 CONAN_TOTAL_PAGES=4
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=1
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=1
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=2
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=2
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=3
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=3
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=4
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=4
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=5
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=5
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=6
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=6
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=7
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=7
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=8
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_CURRENT_PAGE=8
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=1
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=1
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=2
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=2
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=3
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=3
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=4
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=4
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=5
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=5
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=6
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=6
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=7
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=7
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=8
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_CURRENT_PAGE=8
 
 install:
   - chmod +x .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 env:
    global:
-     - CONAN_REFERENCE: "Boost/1.64.0"
+     - CONAN_REFERENCE: "Boost/1.65.1"
      - CONAN_USERNAME: "conan"
      - CONAN_LOGIN_USERNAME: "lasote"
      - CONAN_CHANNEL: "testing"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "Boost/1.64.0"
+    CONAN_REFERENCE: "Boost/1.65.1"
     CONAN_USERNAME: "conan"
     CONAN_LOGIN_USERNAME: "lasote"
     CONAN_CHANNEL: "testing"

--- a/conanfile.py
+++ b/conanfile.py
@@ -121,7 +121,7 @@ class BoostConan(ConanFile):
         self.flags.extend(self.get_build_flags())
 
         # JOIN ALL FLAGS
-        full_command = self.resolve_full_command()
+        full_command = self.resolve_full_command(1)
         self.run("%s -o\"%s%sbuild_report.txt\"" % (full_command, self.build_folder, os.sep))
 
     def get_build_flags(self):
@@ -176,16 +176,17 @@ class BoostConan(ConanFile):
         flags.append(cxx_flags)
         return flags
 
-    def resolve_full_command(self):
+    def resolve_full_command(self, loglevel):
         command = "b2" if self.settings.os == "Windows" else "./b2"
         b2_flags = " ".join(self.flags)
         without_python = "--without-python" if not self.options.python else ""
-        full_command = "cd \"%s\" && %s %s -j%s --abbreviate-paths %s -d2" % (
+        full_command = "cd \"%s\" && %s %s -j%s --abbreviate-paths %s -d%d" % (
             self.FOLDER_NAME,
             command,
             b2_flags,
             tools.cpu_count(),
-            without_python)  # -d2 is to print more debug info and avoid travis timing out without output
+            without_python,
+            loglevel)  
         
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
             full_command = "%s && %s" % (tools.vcvars_command(self.settings), full_command)
@@ -233,9 +234,9 @@ class BoostConan(ConanFile):
             tools.save(filename, tools.load(filename) + contents)
 
     def package(self):
-        command = self.resolve_full_command()
+        command = self.resolve_full_command(0)
 
-        self.run("{1} install --prefix=\"{2}\" --exec-prefix=\"{2}{0}bin\" --libdir=\"{2}{0}lib\" --includedir=\"{2}{0}include\"".format(os.sep, command, self.package_folder))
+        self.run("{1}i install --prefix=\"{2}\" --exec-prefix=\"{2}{0}bin\" --libdir=\"{2}{0}lib\" --includedir=\"{2}{0}include\"".format(os.sep, command, self.package_folder))
 
         if not self.options.header_only and self.settings.compiler == "Visual Studio" and \
             self.options.shared == "False":

--- a/conanfile.py
+++ b/conanfile.py
@@ -359,9 +359,11 @@ class BoostConan(ConanFile):
                 foundlibs[module] = modlibs
 
         # apparently there are exceptions to the b2 build order
-        has_thread = link_modules.index('thread')
-        if has_thread >= 0:
+        try:
+            has_thread = link_modules.index('thread')
             link_modules.insert(0, link_modules.pop(has_thread))
+        except:
+            pass
 
         result = []
         for module in link_modules:

--- a/conanfile.py
+++ b/conanfile.py
@@ -321,7 +321,6 @@ class BoostConan(ConanFile):
 
                 command = line[0:first_space]
                 parts = command.split('.')
-                is_libline = False
                 if self.options.shared:
                     if len(parts) < 3:
                         continue
@@ -359,10 +358,16 @@ class BoostConan(ConanFile):
 
                 foundlibs[module] = modlibs
 
+        # apparently there are exceptions to the b2 build order
+        has_thread = link_modules.index('thread')
+        if has_thread >= 0:
+            link_modules.insert(0, link_modules.pop(has_thread))
+
         result = []
         for module in link_modules:
             result.extend(foundlibs[module])
         result.reverse()
+
         return result
 
     def _msvc_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,90 +1,73 @@
 from conans import ConanFile
 from conans import tools
-import os, sys
+import os, sys, re, pickle 
 
+def boost_apply_modules(mods, opts):
+    res = opts.copy()
+    res.update({"without_" + x: [True, False] for x in mods})
+    return res
 
 class BoostConan(ConanFile):
     name = "Boost"
-    version = "1.64.0"
+    version = "1.65.1"
     settings = "os", "arch", "compiler", "build_type"
     FOLDER_NAME = "boost_%s" % version.replace(".", "_")
     # The current python option requires the package to be built locally, to find default Python
     # implementation
-    options = {
+    modules = (
+            "atomic",
+            "chrono",
+            "container",
+            "context",
+            "coroutine",
+            "coroutine2",
+            "date_time",
+            "exception",
+            "fiber",
+            "filesystem",
+            "graph",
+            "graph_parallel",
+            "iostreams",
+            "locale",
+            "log",
+            "math",
+            "metaparse",
+            "mpi",
+            "program_options",
+            "python",
+            "random",
+            "regex",
+            "serialization",
+            "signals",
+            "system",
+            "test",
+            "thread",
+            "timer",
+            "type_erasure",
+            "wave"
+        )
+
+    options = boost_apply_modules(modules, {
         "shared": [True, False],
         "header_only": [True, False],
         "fPIC": [True, False],
         "python": [True, False],  # Note: this variable does not have the 'without_' prefix to keep
         # the old shas
-        "without_atomic": [True, False],
-        "without_chrono": [True, False],
-        "without_container": [True, False],
-        "without_context": [True, False],
-        "without_coroutine": [True, False],
-        "without_coroutine2": [True, False],
-        "without_date_time": [True, False],
-        "without_exception": [True, False],
-        "without_fiber": [True, False],
-        "without_filesystem": [True, False],
-        "without_graph": [True, False],
-        "without_graph_parallel": [True, False],
-        "without_iostreams": [True, False],
-        "without_locale": [True, False],
-        "without_log": [True, False],
-        "without_math": [True, False],
-        "without_metaparse": [True, False],
-        "without_mpi": [True, False],
-        "without_program_options": [True, False],
-        "without_random": [True, False],
-        "without_regex": [True, False],
-        "without_serialization": [True, False],
-        "without_signals": [True, False],
-        "without_system": [True, False],
-        "without_test": [True, False],
-        "without_thread": [True, False],
-        "without_timer": [True, False],
-        "without_type_erasure": [True, False],
-        "without_wave": [True, False]
-    }
+    })
 
-    default_options = "shared=False", \
-        "header_only=False", \
-        "fPIC=False", \
-        "python=False", \
-        "without_atomic=False", \
-        "without_chrono=False", \
-        "without_container=False", \
-        "without_context=False", \
-        "without_coroutine=False", \
-        "without_coroutine2=False", \
-        "without_date_time=False", \
-        "without_exception=False", \
-        "without_fiber=False", \
-        "without_filesystem=False", \
-        "without_graph=False", \
-        "without_graph_parallel=False", \
-        "without_iostreams=False", \
-        "without_locale=False", \
-        "without_log=False", \
-        "without_math=False", \
-        "without_metaparse=False", \
-        "without_mpi=False", \
-        "without_program_options=False", \
-        "without_random=False", \
-        "without_regex=False", \
-        "without_serialization=False", \
-        "without_signals=False", \
-        "without_system=False", \
-        "without_test=False", \
-        "without_thread=False", \
-        "without_timer=False", \
-        "without_type_erasure=False", \
-        "without_wave=False"
+    default_options = (
+        "shared=False",
+        "header_only=False", 
+        "fPIC=False", 
+        "python=False"
+    ) + tuple("without_" + x + "=False" for x in modules)
 
     url="https://github.com/lasote/conan-boost"
     exports = ["FindBoost.cmake", "OriginalFindBoost*"]
     license="Boost Software License - Version 1.0. http://www.boost.org/LICENSE_1_0.txt"
     short_paths = True
+
+    flags = []
 
     def config_options(self):
         """ First configuration step. Only settings are defined. Options can be removed
@@ -97,6 +80,8 @@ class BoostConan(ConanFile):
         """ Second configuration step. Both settings and options have values, in this case
         we can force static library if MT was specified as runtime
         """
+        # TODO add support for an icu option that adds the icu dependency as needed
+
         if self.settings.compiler == "Visual Studio" and \
            self.options.shared and "MT" in str(self.settings.compiler.runtime):
             self.options.shared = False
@@ -131,30 +116,13 @@ class BoostConan(ConanFile):
             self.output.warn("Header only package, skipping build")
             return
 
-        flags = self.boostrap()
-
+        self.flags = self.boostrap()
         self.patch_project_jam()
-
-        flags.extend(self.get_build_flags())
+        self.flags.extend(self.get_build_flags())
 
         # JOIN ALL FLAGS
-        b2_flags = " ".join(flags)
-
-        command = "b2" if self.settings.os == "Windows" else "./b2"
-
-        without_python = "--without-python" if not self.options.python else ""
-        full_command = "cd %s && %s %s -j%s --abbreviate-paths %s -d2" % (
-            self.FOLDER_NAME,
-            command,
-            b2_flags,
-            tools.cpu_count(),
-            without_python)  # -d2 is to print more debug info and avoid travis timing out without output
-        
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            full_command = "%s && %s" % (tools.vcvars_command(self.settings), full_command)
-      
-        self.output.warn(full_command)
-        self.run(full_command)
+        full_command = self.resolve_full_command()
+        self.run("%s -o\"%s%sbuild_report.txt\"" % (full_command, self.build_folder, os.sep))
 
     def get_build_flags(self):
         flags = []
@@ -177,41 +145,9 @@ class BoostConan(ConanFile):
         flags.append("variant=%s" % str(self.settings.build_type).lower())
         flags.append("address-model=%s" % ("32" if self.settings.arch == "x86" else "64"))
 
-        option_names = {
-            "--without-atomic": self.options.without_atomic,
-            "--without-chrono": self.options.without_chrono,
-            "--without-container": self.options.without_container,
-            "--without-context": self.options.without_context,
-            "--without-coroutine": self.options.without_coroutine,
-            "--without-coroutine2": self.options.without_coroutine2,
-            "--without-date_time": self.options.without_date_time,
-            "--without-exception": self.options.without_exception,
-            "--without-fiber": self.options.without_fiber,
-            "--without-filesystem": self.options.without_filesystem,
-            "--without-graph": self.options.without_graph,
-            "--without-graph_parallel": self.options.without_graph_parallel,
-            "--without-iostreams": self.options.without_iostreams,
-            "--without-locale": self.options.without_locale,
-            "--without-log": self.options.without_log,
-            "--without-math": self.options.without_math,
-            "--without-metaparse": self.options.without_metaparse,
-            "--without-mpi": self.options.without_mpi,
-            "--without-program_options": self.options.without_program_options,
-            "--without-random": self.options.without_random,
-            "--without-regex": self.options.without_regex,
-            "--without-serialization": self.options.without_serialization,
-            "--without-signals": self.options.without_signals,
-            "--without-system": self.options.without_system,
-            "--without-test": self.options.without_test,
-            "--without-thread": self.options.without_thread,
-            "--without-timer": self.options.without_timer,
-            "--without-type_erasure": self.options.without_type_erasure,
-            "--without-wave": self.options.without_wave
-        }
-
-        for option_name, activated in option_names.items():
-            if activated:
-                flags.append(option_name)
+        for mod in self.modules:
+            if getattr(self.options, "without_" + mod):
+                flags.append("--without-" + mod)
 
         cxx_flags = []
         # fPIC DEFINITION
@@ -240,6 +176,22 @@ class BoostConan(ConanFile):
         flags.append(cxx_flags)
         return flags
 
+    def resolve_full_command(self):
+        command = "b2" if self.settings.os == "Windows" else "./b2"
+        b2_flags = " ".join(self.flags)
+        without_python = "--without-python" if not self.options.python else ""
+        full_command = "cd \"%s\" && %s %s -j%s --abbreviate-paths %s -d2" % (
+            self.FOLDER_NAME,
+            command,
+            b2_flags,
+            tools.cpu_count(),
+            without_python)  # -d2 is to print more debug info and avoid travis timing out without output
+        
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            full_command = "%s && %s" % (tools.vcvars_command(self.settings), full_command)
+      
+        return full_command
+
     def boostrap(self):
         with_toolset = {"apple-clang": "darwin"}.get(str(self.settings.compiler),
                                                      str(self.settings.compiler))
@@ -265,31 +217,28 @@ class BoostConan(ConanFile):
 
     def patch_project_jam(self):
         self.output.warn("Patching project-config.jam")
+       
+        if not self.options.without_iostreams and not self.options.header_only:
+            contents = "\nusing zlib : %s : <include>%s <search>%s ;" % (
+                self.requires["zlib"].conan_reference.version,
+                self.deps_cpp_info["zlib"].include_paths[0].replace('\\', '/'),
+                self.deps_cpp_info["zlib"].lib_paths[0].replace('\\', '/'))
+            if self.settings.os == "Linux" or self.settings.os == "Macos":
+                contents += "\nusing bzip2 : %s : <include>%s <search>%s ;" % (
+                    self.requires["bzip2"].conan_reference.version,
+                    self.deps_cpp_info["bzip2"].include_paths[0].replace('\\', '/'),
+                    self.deps_cpp_info["bzip2"].lib_paths[0].replace('\\', '/'))
 
-        contents = "\nusing zlib : %s : <include>%s <search>%s ;" % (
-            self.requires["zlib"].conan_reference.version,
-            self.deps_cpp_info["zlib"].include_paths[0].replace('\\', '/'),
-            self.deps_cpp_info["zlib"].lib_paths[0].replace('\\', '/'))
-        if self.settings.os == "Linux" or self.settings.os == "Macos":
-            contents += "\nusing bzip2 : %s : <include>%s <search>%s ;" % (
-                self.requires["bzip2"].conan_reference.version,
-                self.deps_cpp_info["bzip2"].include_paths[0].replace('\\', '/'),
-                self.deps_cpp_info["bzip2"].lib_paths[0].replace('\\', '/'))
-
-        filename = "%s/project-config.jam" % self.FOLDER_NAME
-        tools.save(filename, tools.load(filename) + contents)
+            filename = "%s/project-config.jam" % self.FOLDER_NAME
+            tools.save(filename, tools.load(filename) + contents)
 
     def package(self):
-        self.copy(pattern="*", dst="include/boost", src="%s/boost" % self.FOLDER_NAME)
-        self.copy(pattern="*.a", dst="lib", src="%s/stage/lib" % self.FOLDER_NAME)
-        self.copy(pattern="*.so", dst="lib", src="%s/stage/lib" % self.FOLDER_NAME)
-        self.copy(pattern="*.so.*", dst="lib", src="%s/stage/lib" % self.FOLDER_NAME)
-        self.copy(pattern="*.dylib*", dst="lib", src="%s/stage/lib" % self.FOLDER_NAME)
-        self.copy(pattern="*.lib", dst="lib", src="%s/stage/lib" % self.FOLDER_NAME)
-        self.copy(pattern="*.dll", dst="bin", src="%s/stage/lib" % self.FOLDER_NAME)
+        command = self.resolve_full_command()
+
+        self.run("{1} install --prefix=\"{2}\" --exec-prefix=\"{2}{0}bin\" --libdir=\"{2}{0}lib\" --includedir=\"{2}{0}include\"".format(os.sep, command, self.package_folder))
 
         if not self.options.header_only and self.settings.compiler == "Visual Studio" and \
-           self.options.shared == "False":
+            self.options.shared == "False":
             # CMake findPackage help
             renames = []
             for libname in os.listdir(os.path.join(self.package_folder, "lib")):
@@ -310,11 +259,17 @@ class BoostConan(ConanFile):
                     self.output.info("Rename: %s => %s" % (original, new))
                     os.rename(original, new)
 
-    def package_info(self):
-        self.cpp_info.libs = self.collect_libs()
+        # save off the libs in a text file for package_info
+        link_libs = self.collect_libs_from_build_log() 
+        with open("%s%slink_library_list.pydata" % (self.package_folder, os.sep), 'wb') as lfile:
+            pickle.dump(link_libs, lfile)
 
-        if self.options.without_test: # remove boost_unit_test_framework
-            self.cpp_info.libs = [lib for lib in self.cpp_info.libs if "unit_test" not in lib]
+    def package_info(self):
+        with open("%s%slink_library_list.pydata" % (self.package_folder, os.sep), 'rb') as lfile:
+            self.cpp_info.libs = pickle.load(lfile)
+
+        if not self.options.shared and self.settings.os == "Linux":
+            self.cpp_info.libs.append("pthread")
 
         self.output.info("LIBRARIES: %s" % self.cpp_info.libs)
 
@@ -331,6 +286,84 @@ class BoostConan(ConanFile):
             if self.settings.compiler == "Visual Studio":
                 # DISABLES AUTO LINKING! NO SMART AND MAGIC DECISIONS THANKS!
                 self.cpp_info.defines.extend(["BOOST_ALL_NO_LIB"])
+
+    def resolve_library(self, library_name):
+        library_name = os.path.basename(library_name.strip())
+
+        # special case for linux shared objects
+        if self.settings.os != "Windows" and self.options.shared:
+            numregex = re.compile(r'(.*)\.\d+$')
+            while True:
+                numsuffixmatch = numregex.match(library_name)
+                if not numsuffixmatch:
+                    break
+                library_name = numsuffixmatch.group(1)
+
+        name, ext = os.path.splitext(library_name)
+        if ext in (".so", ".lib", ".a", ".dylib"):
+            if ext != ".lib" and name.startswith("lib"):
+                name = name[3:]
+        return name
+
+    def collect_libs_from_build_log(self):
+        build_log = "%s%sbuild_report.txt" % (self.build_folder, os.sep)
+
+        libregex = re.compile(r".*\{0}libs\{0}([^\{0}]*)\{0}".format(os.sep))
+        foundlibs = {}
+        foundmodules = set([])
+        link_modules = []
+        with open(build_log) as bf:
+            for line in bf:
+                # split the line
+                first_space = line.find(" ")
+                if first_space < 0:
+                    continue
+
+                command = line[0:first_space]
+                parts = command.split('.')
+                is_libline = False
+                if self.options.shared:
+                    if len(parts) < 3:
+                        continue
+                    if parts[1] != "link" or parts[2] != "dll":
+                        continue
+                else:
+                    if len(parts) < 2:
+                        continue
+                    if parts[1] != "archive":
+                        continue
+
+                match = libregex.match(line[first_space+1:-1])
+                if not match:
+                    continue
+
+                module = match.group(1)
+                if not module in foundmodules:
+                    try:
+                        module_disabled = getattr(self.options, "without_" + module)
+                        if module_disabled:
+                            continue
+                    except:
+                        pass
+
+                    foundmodules.add(module)
+                    link_modules.append(module)
+
+                library_name = self.resolve_library(line[first_space+1:-1])
+                modlibs = None
+                if not module in foundlibs:
+                    modlibs = [library_name]
+                else:
+                    modlibs = foundlibs[module]
+                    modlibs.append(library_name)
+
+                foundlibs[module] = modlibs
+
+        result = []
+        for module in link_modules:
+            result.extend(foundlibs[module])
+        result.reverse()
+        return result
 
     def _msvc_version(self):
         if self.settings.compiler.version == "15":

--- a/conanfile.py
+++ b/conanfile.py
@@ -230,7 +230,7 @@ class BoostConan(ConanFile):
                     self.deps_cpp_info["bzip2"].include_paths[0].replace('\\', '/'),
                     self.deps_cpp_info["bzip2"].lib_paths[0].replace('\\', '/'))
 
-            filename = "%s/project-config.jam" % self.FOLDER_NAME
+            filename = "%s%sproject-config.jam" % (self.FOLDER_NAME, os.sep)
             tools.save(filename, tools.load(filename) + contents)
 
     def package(self):


### PR DESCRIPTION
This repo doesn't seem to have any type of HEAD that all of the releases are branched from. So I'm not sure where to post the Merge Request, or from which branch to build it off of.

This PR has a few elements:

1.  Streamline the management of the various boost modules and the flags / libraries
2.  Fix #60 by replicating the if statement from configure in patch_project_jam
3.  Redo the way that libraries are collected by using the b2 build log
    1.  For the most part, boost build builds packages in resolved dependency order such that a package `a`, that is a dependency for another package `b` will be built before `b`, and thus will appear in the build log before b. I've found one exception to this so far.
        1. I'll take this moment to publicly lament that the boost project built this big fancy build system that only compiles code. Boost inter-dependencies are expressed in a rich DSL and is used to generate shell commands. Unfortunately, there's no way to query the interpreted build to see which boost libraries depend on which. Boostdep is a thing. But it doesn't seem to have been kept up to date. It only recognizes one module.
    2.  So by using the build log to collect the modules and associated libraries to build, we can reverse the list, and fix #62
