### PR TITLE
Renamed to use lowercase 'boost', and removed deprecated (removed) 'conanfile_directory' attribute

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import platform, os, sys
 
 
 class BoostConan(ConanFile):
-    name = "Boost"
+    name = "boost"
     version = "1.60.0"
     settings = "os", "arch", "compiler", "build_type"
     FOLDER_NAME = "boost_%s" % version.replace(".", "_")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile
 from conans import tools
-import platform, os, sys
+import os, sys
 
 
 class BoostConan(ConanFile):

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -17,16 +17,17 @@ class DefaultNameConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     requires = "boost/1.60.0@%s/%s" % (username, channel)
     generators = "cmake"
+    exports  = "data.txt"
 
     def config(self):
         if self.options["boost"].header_only:
             self.settings.clear()
 
     def build(self):
-        cmake = CMake(self.settings)
+        cmake = CMake(self)
         header_only = "-DHEADER_ONLY=TRUE " if self.options["boost"].header_only else ""
         with_python = "-DWITH_PYTHON=True" if self.options["boost"].python else ""
-        self.run('cmake "%s" %s %s %s' % (self.conanfile_directory, cmake.command_line, header_only, with_python))
+        self.run('cmake "%s" %s %s %s' % (self.source_folder, cmake.command_line, header_only, with_python))
         self.run("cmake --build . %s" % cmake.build_config)
 
     def imports(self):
@@ -34,7 +35,7 @@ class DefaultNameConan(ConanFile):
         self.copy(pattern="*.dylib", dst="bin", src="lib")
         
     def test(self):        
-        data_file = os.path.join(self.conanfile_directory, "data.txt")
+        data_file = os.path.join(self.source_folder, "data.txt")
         self.run("cd bin && .%slambda < %s" % (os.sep, data_file))
         if not self.options["boost"].header_only:
             self.run("cd bin && .%sregex_exe < %s" % (os.sep, data_file))

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -15,17 +15,17 @@ class DefaultNameConan(ConanFile):
     name = "DefaultName"
     version = "0.1"
     settings = "os", "compiler", "arch", "build_type"
-    requires = "Boost/1.60.0@%s/%s" % (username, channel)
+    requires = "boost/1.60.0@%s/%s" % (username, channel)
     generators = "cmake"
 
     def config(self):
-        if self.options["Boost"].header_only:
+        if self.options["boost"].header_only:
             self.settings.clear()
 
     def build(self):
         cmake = CMake(self.settings)
-        header_only = "-DHEADER_ONLY=TRUE " if self.options["Boost"].header_only else ""
-        with_python = "-DWITH_PYTHON=True" if self.options["Boost"].python else ""
+        header_only = "-DHEADER_ONLY=TRUE " if self.options["boost"].header_only else ""
+        with_python = "-DWITH_PYTHON=True" if self.options["boost"].python else ""
         self.run('cmake "%s" %s %s %s' % (self.conanfile_directory, cmake.command_line, header_only, with_python))
         self.run("cmake --build . %s" % cmake.build_config)
 
@@ -36,9 +36,9 @@ class DefaultNameConan(ConanFile):
     def test(self):        
         data_file = os.path.join(self.conanfile_directory, "data.txt")
         self.run("cd bin && .%slambda < %s" % (os.sep, data_file))
-        if not self.options["Boost"].header_only:
+        if not self.options["boost"].header_only:
             self.run("cd bin && .%sregex_exe < %s" % (os.sep, data_file))
-            if self.options["Boost"].python:
+            if self.options["boost"].python:
                 os.chdir("bin")
                 sys.path.append(".")
                 import hello_ext


### PR DESCRIPTION
Updated the recipe for 1.60.0 to work with conan > 1.0.2.  Specifically this meant removing the deprecated (and now missing) `conanfile_directory`, but I laos renamed it from `Boost` to `boost` to fit in to the more recent naming convention.