### PR TITLE
Upcase bools to avoid error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you handle multiple dependencies in your project is better to add a *conanfil
     boost/1.66.0@conan/stable
 
     [options]
-    boost:shared=true # false
+    boost:shared=True # False
     # Take a look for all available options in conanfile.py
 
     [generators]


### PR DESCRIPTION
When running using lower case bools in conan 1.0.4 you receive the following error:
```
error: invalid line 5: ERROR: boost/1.66.0@conan/stable: 'true' is not a valid 'options.shared' value.
error: invalid line 6: Possible values are ['False', 'True']
```
This just helps copy/paste errors from the README.md