### PR TITLE
CMake 3.11 needs the architecture tag in order to find the boost 1.66.0 libraries

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -317,10 +317,6 @@ class BoostConan(ConanFile):
                 elif "-sgd-" in libname:
                     new_name = new_name.replace("-sgd-", "-gd-")
 
-            for arch in ["x", "a", "i", "s", "m", "p"]:  # Architectures
-                for addr in ["32", "64"]:  # Model address
-                    new_name = new_name.replace("-%s%s-" % (arch, addr), "-")
-
             renames.append([libpath, os.path.join(self.package_folder, "lib", new_name)])
 
         for original, new in renames:


### PR DESCRIPTION
As references in the [issue 89](https://github.com/conan-community/conan-boost/issues/89), CMake 3.11 needs the architecture tag in order to find the boost 1.66.0 libraries.