### PR TITLE
Detect glibc version and add -lrt if needed

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -321,31 +321,6 @@ class BoostConan(ConanFile):
                 self.output.info("Rename: %s => %s" % (original, new))
                 os.rename(original, new)
 
-    def _get_glibc_version(self):
-        def subprocess_wrapper(cmd):
-            import subprocess, sys
-            output = None
-            if sys.version_info >= (3, 5):
-                output = subprocess.run(args=cmd, stdout=subprocess.PIPE)
-                if output.returncode == 0:
-                    output = str(output.stdout).split('\\n')[0]
-                else:
-                    output = None
-            else:
-                try:
-                    output = subprocess.check_output(args=cmd)
-                except subprocess.CalledProcessError:
-                    output = None
-            return output
-
-        import re
-        glibc_version = subprocess_wrapper(["ldd", "--version"])
-        if glibc_version is not None:
-            regex_res = re.search(r'[0-9]+\.[0-9]+', glibc_version)
-            if regex_res is not None:
-                return regex_res.group(0)
-        return None
-
     def package_info(self):
         gen_libs = tools.collect_libs(self)
 
@@ -373,11 +348,7 @@ class BoostConan(ConanFile):
             self.cpp_info.libs = [lib for lib in self.cpp_info.libs if "unit_test" not in lib]
 
         if self.settings.os == "Linux":
-            glibc_version = self._get_glibc_version()
-            if glibc_version is not None and glibc_version < "2.17":
-                self.output.info("glibc version {} < 2.17: add -lrt".format(glibc_version))
-                self.cpp_info.sharedlinkflags.append('-lrt')
-                self.cpp_info.exelinkflags.append('-lrt')
+            self.cpp_info.libs.append("rt")
 
         self.output.info("LIBRARIES: %s" % self.cpp_info.libs)
         self.output.info("Package folder: %s" % self.package_folder)


### PR DESCRIPTION
I was using RedHat 6.4 (old but still supported) and got a linker error of this kind: [\[stackoverflow\] Another “undefined reference” error when linking boost libraries](https://stackoverflow.com/questions/13653361/another-undefined-reference-error-when-linking-boost-libraries)
I don't have the original one anymore at disposal. The library I was building depended on boost_chono. One of the missing symbol was `clock_gettime`.

The issue come from the version of glibc I was using : 2.12
```
# man clock_gettime
...
    Link with -lrt (only for glibc versions before 2.17).
...
```

I added a check on glibc version. What do you think about it ?