### PR TITLE
check existance of the bootstrap.log before output

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -281,7 +281,7 @@ class BoostConan(ConanFile):
                     self.run(cmd)
         except Exception as exc:
             self.output.warn(str(exc))
-            if os.path.join(folder, "bootstrap.log"):
+            if os.path.exists(os.path.join(folder, "bootstrap.log")):
                 self.output.warn(tools.load(os.path.join(folder, "bootstrap.log")))
             raise
         return os.path.join(folder, "b2.exe") if tools.os_info.is_windows else os.path.join(folder, "b2")


### PR DESCRIPTION
check the actual existence of the bootstrap log instead of only joining its path, to avoid misleading error msgs.