### PR TITLE
Use self.user and self.channel also for depencies bzip2 and zlib.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -48,10 +48,10 @@ class BoostConan(ConanFile):
 
     def configure(self):
         if self.zip_bzip2_requires_needed:
-            self.requires("bzip2/1.0.6@conan/stable")
+            self.requires("bzip2/1.0.6@%s/%s" % (self.user, self.channel))
             self.options["bzip2"].shared = False
             
-            self.requires("zlib/1.2.11@conan/stable")
+            self.requires("zlib/1.2.11@%s/%s" % (self.user, self.channel))
             self.options["zlib"].shared = False
 
     def package_id(self):


### PR DESCRIPTION
Prefer to have my own user and channel for my builds (bzip2 and zlib) .
This patch uses the same channels for dependencies as used to build boost.