### PR TITLE
Fix #118 - Add 'contract' to lib_list to allow explicit enabling and disabling

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 # From from *1 (see below, b2 --show-libraries), also ordered following linkage order
 # see https://github.com/Kitware/CMake/blob/master/Modules/FindBoost.cmake to know the order
 
-lib_list = ['math', 'wave', 'container', 'exception', 'graph', 'iostreams', 'locale', 'log',
+lib_list = ['math', 'wave', 'container', 'contract', 'exception', 'graph', 'iostreams', 'locale', 'log',
             'program_options', 'random', 'regex', 'mpi', 'serialization', 'signals',
             'coroutine', 'fiber', 'context', 'timer', 'thread', 'chrono', 'date_time',
             'atomic', 'filesystem', 'system', 'graph_parallel', 'python',


### PR DESCRIPTION
BCP in #118 showed that Boost.Contract depends on these libraries:
`atomic, chrono, date_time, exception, system, thread`

However local testing using `without_contract=False` and the rest set to `True` concluded in only `libboost_contract` and `libboost_system` being created and needed to work.

Furthermore it didn't matter where on the `lib_list` the `contract` was put, it still linked correctly.

I prefered to stay on the safe side and left it before `exception`.