### PR TITLE
1.66.0: Added Apple-Clang 7.3/8.1 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,30 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50 CONAN_CURRENT_PAGE=12 CONAN_TOTAL_PAGES=12
       - <<: *osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=1 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=2 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=3 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=4 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=1 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=2 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=3 CONAN_TOTAL_PAGES=4
+      - <<: *osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=4 CONAN_TOTAL_PAGES=4
+      - <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0 CONAN_CURRENT_PAGE=1 CONAN_TOTAL_PAGES=4
       - <<: *osx


### PR DESCRIPTION
Last builds to be on pair with [bincrafters/conan-templates](https://github.com/bincrafters/conan-templates), which I believe is a good aim.

To minimize the load on the build server (and time), could you cancel all the unrelated builds?