### PR TITLE
Change ldflags to linkflags in user-config

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -258,7 +258,7 @@ class BoostConan(ConanFile):
         if "CFLAGS" in os.environ:
             contents += '<cflags>"%s" ' % os.environ["CFLAGS"]
         if "LDFLAGS" in os.environ:
-            contents += '<ldflags>"%s" ' % os.environ["LDFLAGS"]
+            contents += '<linkflags>"%s" ' % os.environ["LDFLAGS"]
 
         if self.settings.os == "iOS":
             sdk_name = tools.apple_sdk_name(self.settings)


### PR DESCRIPTION
This fixes a bug where ldflags would be ignored.

See table 49.2 [here](https://www.boost.org/doc/libs/1_66_0/doc/html/bbv2/overview.html)