### PR TITLE
fixed selection of toolset at bootstrap

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -322,7 +322,8 @@ class BoostConan(ConanFile):
             with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
                 self.output.info("Using %s %s" % (self.settings.compiler, self.settings.compiler.version))
                 with tools.chdir(folder):
-                    cmd = "%s -with-toolset=%s" % (bootstrap, self._get_boostrap_toolset())
+                    option = "" if tools.os_info.is_windows else "-with-toolset="
+                    cmd = "%s %s%s" % (bootstrap, option, self._get_boostrap_toolset())
                     self.output.info(cmd)
                     self.run(cmd)
         except Exception as exc:

--- a/conanfile.py
+++ b/conanfile.py
@@ -322,7 +322,7 @@ class BoostConan(ConanFile):
             with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
                 self.output.info("Using %s %s" % (self.settings.compiler, self.settings.compiler.version))
                 with tools.chdir(folder):
-                    cmd = "%s %s" % (bootstrap, self._get_boostrap_toolset())
+                    cmd = "%s -with-toolset=%s" % (bootstrap, self._get_boostrap_toolset())
                     self.output.info(cmd)
                     self.run(cmd)
         except Exception as exc:


### PR DESCRIPTION
GCC `bootstrap.sh` script requires passing the specified toolset `X` (e.g. in a conan user profile) through the option `-with-toolset`, i.e. `bootstrap.sh -with-toolset=X`. Currently, the toolset is passed as is, without specifying the option, i.e. `bootstrap X`, causing the script to ignore it and guessing the toolset from the platform.

This PR solves this bug.