### PR TITLE
Conan passes a C++ standard different from what b2 expects

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,7 @@
 from conans import ConanFile
 from conans import tools
+from conans.client.build.cppstd_flags import cppstd_flag
+
 import os
 import sys
 
@@ -136,7 +138,14 @@ class BoostConan(ConanFile):
                 flags.append("--without-%s" % libname)
 
         if self.settings.cppstd:
-            flags.append("cxxstd=%s" % self.settings.cppstd)
+            toolset, _, _ = self.get_toolset_version_and_exe()
+            flags.append("toolset=%s" % toolset)
+            flags.append("cxxflags=%s" % cppstd_flag(
+                    self.settings.get_safe("compiler"),
+                    self.settings.get_safe("compiler.version"),
+                    self.settings.get_safe("cppstd")
+                )
+            )
 
         # CXX FLAGS
         cxx_flags = []


### PR DESCRIPTION
cxxstd allows 98, 03, 0x, 11, 1y, 14, 1z, 17, 2a, latest.
But we don't want to have to convert to b2 format so it converts again
for the compiler, otherwise standards like "gnu11" can't be passed.
Use cxxflags and C++ standard flags detection code built in conan
instead.

Fixes conan-community/community#100