### PR TITLE
improve python detection and configuration

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -207,7 +207,7 @@ class BoostConan(ConanFile):
 
         candidates = [ldlibrary, library]
         library_prefixes = [""] if self.settings.compiler == "Visual Studio" else ["", "lib"]
-        library_suffixes = [".lib"] if self.settings.compiler == "Visual Studio" else [".so", ".a"]
+        library_suffixes = [".lib"] if self.settings.compiler == "Visual Studio" else [".so", ".dll.a", ".a"]
         if with_dyld:
             library_suffixes.insert(0, ".dylib")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -107,7 +107,7 @@ class BoostConan(ConanFile):
     @property
     def _python_executable(self):
         exe = self.options.python_executable if self.options.python_executable else sys.executable
-        return str(exe)
+        return str(exe).replace('\\', '/')
 
     def _run_python_script(self, script):
         output = StringIO()
@@ -183,7 +183,7 @@ class BoostConan(ConanFile):
                 self.output.info('checking %s' % python_h)
                 if os.path.isfile(python_h):
                     self.output.info('found Python.h: %s' % python_h)
-                    return candidate
+                    return candidate.replace('\\', '/')
         raise Exception("couldn't locate Python.h - make sure you have installed python development files")
 
 
@@ -226,7 +226,7 @@ class BoostConan(ConanFile):
                 self.output.info('checking %s' % python_lib)
                 if os.path.isfile(python_lib):
                     self.output.info('found python library: %s' % python_lib)
-                    return python_lib
+                    return python_lib.replace('\\', '/')
         raise Exception("couldn't locate python libraries - make sure you have installed python development files")
 
     def build(self):
@@ -482,9 +482,9 @@ class BoostConan(ConanFile):
             # https://www.boost.org/doc/libs/1_69_0/libs/python/doc/html/building/configuring_boost_build.html
             contents += "\nusing python : {version} : {executable} : {includes} :  {libraries} ;"\
                 .format(version=self._python_version,
-                        executable=self._python_executable.replace('\\', '/'),
-                        includes=self._python_includes.replace('\\', '/'),
-                        libraries=self._python_libraries.replace('\\', '/'))
+                        executable=self._python_executable,
+                        includes=self._python_includes,
+                        libraries=self._python_libraries)
 
         toolset, version, exe = self.get_toolset_version_and_exe()
         exe = compiler_command or exe  # Prioritize CXX

--- a/conanfile.py
+++ b/conanfile.py
@@ -85,8 +85,7 @@ class BoostConan(ConanFile):
             if self.options.without_python:
                 del self.info.options.python_version
             else:
-                if self.options.python_version is None:
-                    self.info.options.python_version = self._python_version
+                self.info.options.python_version = self._python_version
 
     def source(self):
         if tools.os_info.is_windows:

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class BoostConan(ConanFile):
     exports = ['patches/*']
 
     def config_options(self):
-        if self.settings.compiler == "Visual Studio":
+        if self.settings.os == "Windows":
             self.options.remove("fPIC")
 
     @property
@@ -234,7 +234,7 @@ class BoostConan(ConanFile):
         # CXX FLAGS
         cxx_flags = []
         # fPIC DEFINITION
-        if self.settings.compiler != "Visual Studio":
+        if self.settings.os != "Windows":
             if self.options.fPIC:
                 cxx_flags.append("-fPIC")
 


### PR DESCRIPTION
addresses:
https://github.com/conan-community/community/issues/104
https://github.com/conan-community/community/issues/91
https://github.com/conan-community/community/issues/85

- add option to specify python executable/interpreter (default is system one)
- add option to specify python version (may be automatically deduced from python interpreter)
- use `sysconfig` module to locate python libraries and headers

~~please don't merge for a while, I gonna do some tests in the various environments first~~
(tested, everything seems to be working as expected)
- [x] Windows Python 2.x
- [x] Windows Python 3.x
- [x] Linux Python 2.x
- [x] Linux Python 3.x
- [x] OSX Python 2.x
- [x] OSX Python 3.x
- [x] virtualenv Python 3.x
- [x] PyEnv Python 3.x
- [x] MSYS Python 3.x
- [x] Cygwin Python 3.x

(I collect various python configurations in this repository: https://github.com/SSE4/python_sysconfig_examples)