### PR TITLE
Implemented patch described at https://svn.boost.org/trac10/ticket/13368

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -74,7 +74,7 @@ class BoostConan(ConanFile):
         if 'gcc' == self.settings.compiler and Version(str(self.settings.compiler)) < '6':
             # https://svn.boost.org/trac10/ticket/13368
             tools.replace_in_file(
-                file_path='%s/boost/asio/detail/consuming_buffers.hpp'%self.folder_name,
+                file_path='%s/boost/asio/detail/consuming_buffers.hpp' % self.folder_name,
                 search='&& result.count <',
                 replace='&& (result.count) <'
             )

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile
 from conans import tools
+from conans.model.version import Version
 import os
 
 # From from *1 (see below, b2 --show-libraries), also ordered following linkage order
@@ -69,6 +70,14 @@ class BoostConan(ConanFile):
         zip_name = "%s%s" % (self.folder_name, extension)
         url = "https://dl.bintray.com/boostorg/release/%s/source/%s" % (self.version, zip_name)
         tools.get(url, sha256=sha256)
+
+        if 'gcc' == self.settings.compiler and Version(str(self.settings.compiler)) < '6':
+            # https://svn.boost.org/trac10/ticket/13368
+            tools.replace_in_file(
+                file_path='%s/boost/asio/detail/consuming_buffers.hpp'%self.folder_name,
+                search='&& result.count <',
+                replace='&& (result.count) <'
+            )
 
     ##################### BUILDING METHODS ###########################
 


### PR DESCRIPTION
Without this patch, I received the exact compilation error with gcc, namely:

```
.../boost/boost/boost/asio/detail/consuming_buffers.hpp: In member function ‘boost::asio::detail::consuming_buffers<Buffer, Buffers, Buffer_Iterator>::prepared_buffers_type boost::asio::detail::consuming_buffers<Buffer, Buffers, Buffer_Iterator>::prepare(std::size_t)’:
.../boost/boost/boost/asio/detail/consuming_buffers.hpp:105:50: erreur: parse error in template argument list
     while (next != end && max_size > 0 && result.count < result.max_buffers)
```