### PR TITLE
Fix/asmflags

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -131,6 +131,8 @@ class BoostConan(ConanFile):
 
         tools.patch(base_path=os.path.join(self.source_folder, self.folder_name),
                     patch_file='patches/python_base_prefix.patch', strip=1)
+        tools.patch(base_path=os.path.join(self.source_folder, self.folder_name),
+                    patch_file='patches/boost_build_asmflags.patch', strip=1)
 
     ##################### BUILDING METHODS ###########################
 

--- a/patches/boost_build_asmflags.patch
+++ b/patches/boost_build_asmflags.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/build/src/tools/common.jam b/tools/build/src/tools/common.jam
+index 19eaca51c9..5b9b350854 100644
+--- a/tools/build/src/tools/common.jam
++++ b/tools/build/src/tools/common.jam
+@@ -429,6 +429,7 @@ local rule check-tool ( xcommand + )
+ # - OPTIONS for compile         to the value of <compileflags> in $(options)
+ # - OPTIONS for compile.c       to the value of <cflags>       in $(options)
+ # - OPTIONS for compile.c++     to the value of <cxxflags>     in $(options)
++# - OPTIONS for compile.asm     to the value of <asmflags>     in $(options)
+ # - OPTIONS for compile.fortran to the value of <fflags>       in $(options)
+ # - OPTIONS for link            to the value of <linkflags>    in $(options)
+ #
+@@ -454,6 +455,9 @@ rule handle-options ( toolset : condition * : command * : options * )
+     toolset.flags $(toolset).compile.c++     OPTIONS $(condition) :
+         [ feature.get-values <cxxflags>     : $(options) ] : unchecked ;
+ 
++    toolset.flags $(toolset).compile.asm     OPTIONS $(condition) :
++        [ feature.get-values <asmflags>     : $(options) ] : unchecked ;
++
+     toolset.flags $(toolset).compile.fortran OPTIONS $(condition) :
+         [ feature.get-values <fflags>       : $(options) ] : unchecked ;
+ 
+diff --git a/tools/build/src/tools/common.py b/tools/build/src/tools/common.py
+index d0e2a387e0..8f6cbfff1a 100644
+--- a/tools/build/src/tools/common.py
++++ b/tools/build/src/tools/common.py
+@@ -441,6 +441,7 @@ def handle_options(tool, condition, command, options):
+         - OPTIOns for compile to the value of <compileflags> in options
+         - OPTIONS for compile.c to the value of <cflags> in options
+         - OPTIONS for compile.c++ to the value of <cxxflags> in options
++        - OPTIONS for compile.asm to the value of <asmflags> in options
+         - OPTIONS for compile.fortran to the value of <fflags> in options
+         - OPTIONs for link to the value of <linkflags> in options
+     """
+@@ -454,6 +455,7 @@ def handle_options(tool, condition, command, options):
+     toolset.flags(tool + '.compile', 'OPTIONS', condition, feature.get_values('<compileflags>', options))
+     toolset.flags(tool + '.compile.c', 'OPTIONS', condition, feature.get_values('<cflags>', options))
+     toolset.flags(tool + '.compile.c++', 'OPTIONS', condition, feature.get_values('<cxxflags>', options))
++    toolset.flags(tool + '.compile.asm', 'OPTIONS', condition, feature.get_values('<asmflags>', options))
+     toolset.flags(tool + '.compile.fortran', 'OPTIONS', condition, feature.get_values('<fflags>', options))
+     toolset.flags(tool + '.link', 'OPTIONS', condition, feature.get_values('<linkflags>', options))
+ 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -24,6 +24,8 @@ class DefaultNameConan(ConanFile):
         cmake.build()
 
     def test(self):
+        if tools.cross_building(self.settings):
+            return
         bt = self.settings.build_type
         re = RunEnvironment(self)
         with tools.environment_append(re.vars):


### PR DESCRIPTION
Hi, this PR fixes cross-build issues with Boost.Context assembly flags.

It requires https://github.com/conan-community/conan-zlib/pull/78 and #174 to be merged first.