### PR TITLE
Use 'darwin' bootstrap toolchain if host os is Macos

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -738,6 +738,9 @@ class BoostConan(ConanFile):
         if tools.os_info.is_windows:
             return ""
 
+        if tools.os_info.is_macos:
+            return "darwin"
+
         with_toolset = {"apple-clang": "darwin"}.get(str(self.settings.compiler),
                                                      str(self.settings.compiler))
 


### PR DESCRIPTION
Based on suggested profile for Android

https://docs.conan.io/en/latest/integrations/android_studio.html

Current `conanfile.py` will lead to `./bootstrap.sh -with-toolset=clang` and as result produce ARM executable

```
/Users/camobap/.conan/data/boost/1.69.0/conan/stable/source/boost_1_69_0/tools/build/src/engine/bootstrap/jam0: ELF 32-bit LSB pie executable ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /system/bin/linker, with debug_info, not stripped
```