### PR TITLE
Fix static object initialization under Visual Studio 2017

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -130,6 +130,8 @@ class BoostConan(ConanFile):
         tools.get(url, sha256=sha256)
 
         tools.patch(base_path=os.path.join(self.source_folder, self.folder_name),
+                    patch_file='patches/static_object_init.patch', strip=1)
+        tools.patch(base_path=os.path.join(self.source_folder, self.folder_name),
                     patch_file='patches/python_base_prefix.patch', strip=1)
         tools.patch(base_path=os.path.join(self.source_folder, self.folder_name),
                     patch_file='patches/boost_build_asmflags.patch', strip=1)

--- a/patches/static_object_init.patch
+++ b/patches/static_object_init.patch
@@ -1,7 +1,6 @@
-diff --git a/include/boost/python/detail/caller.hpp b/include/boost/python/detail/caller.hpp
-index 1bd30bfb5..a2fc08ed6 100644
---- a/include/boost/python/detail/caller.hpp
-+++ b/include/boost/python/detail/caller.hpp
+diff --ru a/boost/python/detail/caller.hpp b/boost/python/detail/caller.hpp
+--- a/boost/python/detail/caller.hpp
++++ b/boost/python/detail/caller.hpp
 @@ -109,6 +109,21 @@ struct converter_target_type <void_result_to_python >
          return 0;
      }

--- a/patches/static_object_init.patch
+++ b/patches/static_object_init.patch
@@ -1,0 +1,45 @@
+diff --git a/include/boost/python/detail/caller.hpp b/include/boost/python/detail/caller.hpp
+index 1bd30bfb5..a2fc08ed6 100644
+--- a/include/boost/python/detail/caller.hpp
++++ b/include/boost/python/detail/caller.hpp
+@@ -109,6 +109,21 @@ struct converter_target_type <void_result_to_python >
+         return 0;
+     }
+ };
++
++template<class Policies, class Sig> const signature_element* get_ret()
++{
++	typedef BOOST_DEDUCED_TYPENAME Policies::template extract_return_type<Sig>::type rtype;
++	typedef typename select_result_converter<Policies, rtype>::type result_converter;
++	
++	static const signature_element ret = {
++		(is_void<rtype>::value ? "void" : type_id<rtype>().name())
++		, &detail::converter_target_type<result_converter>::get_pytype
++		, boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value 
++	};
++	
++	return &ret;
++};
++
+ #endif
+ 
+     
+@@ -229,16 +244,9 @@ struct caller_arity<N>
+         {
+             const signature_element * sig = detail::signature<Sig>::elements();
+ #ifndef BOOST_PYTHON_NO_PY_SIGNATURES
++			const signature_element * ret = detail::get_ret<Policies, Sig>();
+ 
+-            typedef BOOST_DEDUCED_TYPENAME Policies::template extract_return_type<Sig>::type rtype;
+-            typedef typename select_result_converter<Policies, rtype>::type result_converter;
+-
+-            static const signature_element ret = {
+-                (is_void<rtype>::value ? "void" : type_id<rtype>().name())
+-                , &detail::converter_target_type<result_converter>::get_pytype
+-                , boost::detail::indirect_traits::is_reference_to_non_const<rtype>::value 
+-            };
+-            py_func_sig_info res = {sig, &ret };
++            py_func_sig_info res = {sig, ret };
+ #else
+             py_func_sig_info res = {sig, sig };
+ #endif


### PR DESCRIPTION
Doc string in boost python causes a crash in VS2017. The patch was taken from:  
https://github.com/boostorg/python/pull/208/commits/016b12e5e9e7f29f5c3ac188042fb664da255f0b