### PR TITLE
Allow disabling automatic addition of -isysroo on macOS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -681,7 +681,8 @@ class BoostConan(ConanFile):
         contents += ' %s' % exe.replace("\\", "/")
 
         if tools.is_apple_os(self.settings.os):
-            contents += " -isysroot %s" % tools.XCRun(self.settings).sdk_path
+            if self.settings.compiler == "apple-clang":
+                contents += " -isysroot %s" % tools.XCRun(self.settings).sdk_path
             if self.settings.get_safe("arch"):
                 contents += " -arch %s" % tools.to_apple_arch(self.settings.arch)
 


### PR DESCRIPTION
I would like to build my dependencies with a custom clang/libc++ version. By adding the `-isysroot` parameter this recipe forces my custom clang into using the libc++ provided by Xcode which fails.

The patch in this PR is a fix that works for me but it is a bit cumbersome because the using package needs to disable the additional `with_isysroot=` option when appropriate. I am open for a better idea. :) It would be great if the recipe would detect the custom clang/libc++ somehow and automagically refrain from adding `-isysroot`.