### PR TITLE
bootstrap toolset to gcc on windows, compiler=gcc

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -746,7 +746,7 @@ class BoostConan(ConanFile):
             return "vc%s" % ("141" if Version(str(comp_ver)) >= "15" else comp_ver)
 
         if tools.os_info.is_windows:
-            return ""
+            return "gcc" if self.settings.compiler == "gcc" else ""
 
         if tools.os_info.is_macos:
             return "darwin"


### PR DESCRIPTION
### Description of Problem
Error in Building boost on windows using 'mingw_installer/1.0@conan/stable'. Bootstrap toolset is set to msvc however I'm using gcc as my compiler. **I have fixed the error** by modifying _get_boostrap_toolset() at conanfile.py as follows:

```
if tools.os_info.is_windows:
    return "gcc" if self.settings.compiler == "gcc" else "" # instead of return ""
```
If you look in boost bootstrap.bat file you can find that toolset can be set to "gcc" on windows


### System information
* Package Name/Version: **boost/1.70.0@conan/stable**
* Operating System: **Windows**
* Operation System Version: **Windows 10**
* Compiler+version: **gcc-8.0**
* Conan version: **conan 1.15**
* Python version: **python 3.7.0**

### Steps to reproduce
* run conan install boost/1.70.0@conan/stable --build missing --profile  mingw_profile
* msvc not installed
* Use the following profile, (let's call it mingw_profile):
```
[build_requires]
mingw_installer/1.0@conan/stable
cmake_installer/3.10.0@conan/stable

[settings]
os=Windows
os_build=Windows
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.version=8
compiler.libcxx=libstdc++11
compiler.cppstd=17
compiler.exception=seh
compiler.threads=posix
[options]
[env]
```


### Build logs (Include if Available)

The error after conan install command is:
```
> boost/1.70.0@conan/stable: bootstrap.bat
Bootstrapping the build engine
'cl' is not recognized as an internal or external command,
operable program or batch file.

Failed to bootstrap the build engine
Please consult bootstrap.log for further diagnostics.

boost/1.70.0@conan/stable: WARN: Error 9009 while executing bootstrap.bat
boost/1.70.0@conan/stable: WARN: could not find "vswhere"
###
### Using 'msvc' toolset.
###
```
