### PR TITLE
Clear CC/CXX/CFLAGS/CXXFLAGS for bootstrapping step

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -771,7 +771,8 @@ class BoostConan(ConanFile):
                         option = "" if tools.os_info.is_windows else "-with-toolset="
                         cmd = "%s %s%s" % (bootstrap, option, self._get_boostrap_toolset())
                     self.output.info(cmd)
-                    self.run(cmd)
+                    with tools.environment_append({"CC": None, "CXX": None, "CFLAGS": None, "CXXFLAGS": None}):
+                        self.run(cmd)
 
         except Exception as exc:
             self.output.warn(str(exc))


### PR DESCRIPTION
The bootstrapping step of the boost build should clear the CC and CXX variables from the environment (and probably also CFLAGS and CXXFLAGS to be safe). These might be set to a cross-compiler and its options if we're building from a cross-compilation environment, making the bootstrapper build b2 for the target architecture, which is not what we want.