### PR TITLE
Requirements should be defined in requirements(), not in configure()

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -97,6 +97,9 @@ class BoostConan(ConanFile):
         return not self.options.without_iostreams and not self.options.header_only
 
     def configure(self):
+        pass
+
+    def requirements(self):
         if self.zip_bzip2_requires_needed:
             if self.options.zlib:
                 self.requires("zlib/1.2.11@conan/stable")


### PR DESCRIPTION
If one tries to build a conan package of libA overloading the following recipes
```
boost = boost/1.70.0-2@pix4d/stable
libB = libB/1.0.0@pix4d/stable
zlib = zlib/1.2.11@conan/stable
```
and if libB also depends on `boost/1.70.0-2@pix4d/stable`, one gets the following error:

```
ERROR: boost/1.70.0-2@pix4d/stable: Error in configure() method, line 104
   self.requires("zlib/[>=1.2.11]@conan/stable")
   ConanException: Duplicated requirement zlib/1.2.11@conan/stable != zlib/[>=1.2.11]@conan/stable
```

The problem is solved by defining requirements in the  `requirements()` method and not in the `configure()` method.